### PR TITLE
Remove Cursor extension installation and clean up configs

### DIFF
--- a/configs/cursor/settings.json
+++ b/configs/cursor/settings.json
@@ -1,5 +1,4 @@
 {
-  // Editor appearance
   "workbench.colorTheme": "Tokyo Night",
   "editor.fontFamily": "Cascadia code",
   "editor.fontSize": 14,
@@ -8,7 +7,6 @@
   "editor.rulers": [80, 120],
   "editor.letterSpacing": -0.25,
 
-  // Editor behavior
   "editor.formatOnSave": true,
   "editor.multiCursorModifier": "alt",
   "editor.trimAutoWhitespace": true,
@@ -25,30 +23,24 @@
   "editor.guides.bracketPairs": true,
   "editor.autoClosingOvertype": "never",
 
-  // File handling
   "files.autoSave": "onFocusChange",
   "files.associations": {
     "*.html.erb": "erb"
   },
 
-  // Workspace and startup
   "security.workspace.trust.untrustedFiles": "open",
 
-  // Telemetry and updates
   "typescript.surveys.enabled": false,
   "update.showReleaseNotes": false,
 
-  // Tailwind CSS
   "tailwindCSS.includeLanguages": {
     "ruby": "html",
     "erb": "html"
   },
 
-  // Git and GitHub settings
   "git.autofetch": true,
   "git.confirmSync": false,
 
-  // Ruby LSP settings
   "rubyLsp.pullDiagnosticsOn": "save",
   "rubyLsp.enabledFeatures": {
     "codeActions": true,
@@ -76,7 +68,6 @@
   },
   "rubyLsp.erbSupport": true,
 
-  // Language-specific settings
   "[ruby]": {
     "tailwindCSS.experimental.classRegex": ["\\bclass:\\s*[\"']([^\"']*)[\"']"],
     "editor.formatOnSave": true,

--- a/configs/zed/settings.json
+++ b/configs/zed/settings.json
@@ -7,10 +7,10 @@
   "buffer_font_features": {
     "calt": true,
     "liga": true,
-    "dlig": true
+    "dlig": true,
   },
   "buffer_line_height": {
-    "custom": 1.5
+    "custom": 1.5,
   },
   "soft_wrap": "editor_width",
   "preferred_line_length": 100,
@@ -38,14 +38,14 @@
     "*.erb": ["ERB"],
     "*.html.erb": ["ERB"],
     "*.heex": ["HEEx"],
-    "*.leex": ["HEEx"]
+    "*.leex": ["HEEx"],
   },
   "base_keymap": "VSCode",
   "show_call_status_icon": false,
   "autosave": {
     "after_delay": {
-      "milliseconds": 1000
-    }
+      "milliseconds": 1000,
+    },
   },
   "confirm_quit": false,
   "restore_on_startup": "last_workspace",
@@ -77,7 +77,7 @@
     "**/.turbo",
     "**/.vercel",
     "**/package-lock.json",
-    "**/yarn.lock"
+    "**/yarn.lock",
   ],
   "inlay_hints": {
     "enabled": true,
@@ -85,23 +85,23 @@
     "show_parameter_hints": false,
     "show_other_hints": true,
     "edit_debounce_ms": 700,
-    "scroll_debounce_ms": 50
+    "scroll_debounce_ms": 50,
   },
   "git": {
     "git_gutter": "tracked_files",
     "inline_blame": {
       "enabled": true,
-      "delay_ms": 600
-    }
+      "delay_ms": 600,
+    },
   },
   "terminal": {
     "font_size": 14,
     "font_family": "Google Sans Code",
     "line_height": {
-      "custom": 1.4
+      "custom": 1.4,
     },
     "shell": {
-      "program": "zsh"
+      "program": "zsh",
     },
     "copy_on_select": true,
     "dock": "bottom",
@@ -110,13 +110,13 @@
     "detect_venv": {
       "on": {
         "directories": [".env", "env", ".venv", "venv"],
-        "activate_script": "default"
-      }
-    }
+        "activate_script": "default",
+      },
+    },
   },
   "telemetry": {
     "diagnostics": false,
-    "metrics": false
+    "metrics": false,
   },
   "disable_ai": true,
   "lsp": {
@@ -137,9 +137,9 @@
           "semanticHighlighting": true,
           "completion": true,
           "codeLens": false,
-          "debugging": true
-        }
-      }
+          "debugging": true,
+        },
+      },
     },
     "typescript-language-server": {
       "initialization_options": {
@@ -151,22 +151,22 @@
           "includeInlayFunctionLikeReturnTypeHints": true,
           "includeInlayEnumMemberValueHints": true,
           "importModuleSpecifierPreference": "shortest",
-          "quotePreference": "single"
-        }
-      }
+          "quotePreference": "single",
+        },
+      },
     },
     "tailwindcss-language-server": {
       "settings": {
         "includeLanguages": {
           "erb": "html",
           "eex": "html",
-          "heex": "html"
+          "heex": "html",
         },
         "experimental": {
-          "classRegex": [["class[:]\\s*\"([^\"]*)\"", "([a-zA-Z0-9\\s\\-:]+)"]]
-        }
-      }
-    }
+          "classRegex": [["class[:]\\s*\"([^\"]*)\"", "([a-zA-Z0-9\\s\\-:]+)"]],
+        },
+      },
+    },
   },
   "languages": {
     "Ruby": {
@@ -176,13 +176,13 @@
       "formatter": {
         "external": {
           "command": "rubocop",
-          "arguments": ["-a", "--stdin", "{buffer_path}", "--stderr"]
-        }
+          "arguments": ["-a", "--stdin", "{buffer_path}", "--stderr"],
+        },
       },
       "language_servers": ["ruby-lsp", "!solargraph"],
       "inlay_hints": {
-        "enabled": false
-      }
+        "enabled": false,
+      },
     },
     "JavaScript": {
       "tab_size": 2,
@@ -190,8 +190,8 @@
       "format_on_save": "on",
       "formatter": "prettier",
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
+        "source.fixAll.eslint": true,
+      },
     },
     "TypeScript": {
       "tab_size": 2,
@@ -199,8 +199,8 @@
       "format_on_save": "on",
       "formatter": "prettier",
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
+        "source.fixAll.eslint": true,
+      },
     },
     "TSX": {
       "tab_size": 2,
@@ -208,24 +208,27 @@
       "format_on_save": "on",
       "formatter": "prettier",
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
+        "source.fixAll.eslint": true,
+      },
     },
     "ERB": {
       "tab_size": 2,
       "hard_tabs": false,
       "format_on_save": "on",
-      "language_servers": ["herb", "ruby-lsp", "..."]
+      "language_servers": ["herb", "ruby-lsp", "..."],
     },
     "HTML+ERB": {
       "format_on_save": "on",
       "formatter": {
         "external": {
           "command": "herb-format",
-          "arguments": []
-        }
+          "arguments": [],
+        },
       },
-      "language_servers": ["herb", "ruby-lsp", "..."]
-    }
-  }
+      "language_servers": ["herb", "ruby-lsp", "..."],
+    },
+    "CSS": {
+      "language_servers": ["tailwindcss-language-server"],
+    },
+  },
 }

--- a/scripts/cursor.sh
+++ b/scripts/cursor.sh
@@ -27,24 +27,4 @@ fi
 step "Installing Cursor settings..."
 cp configs/cursor/settings.json "$CURSOR_USER_DIR/settings.json"
 
-# Install extensions
-step "Installing Cursor extensions..."
-if [ -f "configs/cursor/extensions.txt" ]; then
-  CURSOR_PATH="/Applications/Cursor.app/Contents/MacOS/Cursor"
-  if [ ! -f "$CURSOR_PATH" ]; then
-    print_error "Cursor executable not found at: $CURSOR_PATH"
-    exit 1
-  fi
-
-  while IFS= read -r extension || [ -n "$extension" ]; do
-    if [ ! -z "$extension" ]; then
-      print_muted "Installing extension: $extension"
-      "$CURSOR_PATH" --install-extension "$extension" >/dev/null 2>&1 || print_warning "Failed to install extension: $extension"
-    fi
-  done <"configs/cursor/extensions.txt"
-  print_success_muted "Extensions installed successfully!"
-else
-  print_warning "Extensions file not found at configs/cursor/extensions.txt"
-fi
-
 print_success "Cursor setup completed!"


### PR DESCRIPTION
## Summary
- Remove extension installation logic from `scripts/cursor.sh` to simplify Cursor setup
- Remove section comments from Cursor settings for cleaner JSON
- Add trailing commas to Zed settings for consistency
- Add CSS language server config for Tailwind in Zed

## Test plan
- [ ] Run `./scripts/cursor.sh` and verify settings are applied without errors
- [ ] Run `./scripts/zed.sh` and verify Zed settings are applied correctly
- [ ] Verify Tailwind CSS IntelliSense works in Zed for CSS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)